### PR TITLE
Add training overlay for reference tab

### DIFF
--- a/src/components/app/reference-tab.tsx
+++ b/src/components/app/reference-tab.tsx
@@ -27,6 +27,7 @@ import { useToast } from "@/hooks/use-toast";
 import { fileToBase64 } from "@/lib/utils";
 import { Bot, CheckCircle, Loader2, Upload } from "lucide-react";
 import Image from "next/image";
+import { TrainingDialog } from "@/components/app/training-dialog";
 
 const formSchema = z.object({
   referenceImages: z
@@ -101,7 +102,9 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
   };
 
   return (
-    <Card className="max-w-3xl mx-auto shadow-lg">
+    <>
+      <TrainingDialog open={isLoading} />
+      <Card className="max-w-3xl mx-auto shadow-lg">
       <CardHeader>
         <CardTitle className="flex items-center gap-2 text-xl font-headline">
           <Bot />
@@ -197,5 +200,6 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
         </form>
       </Form>
     </Card>
+    </>
   );
 }

--- a/src/components/app/training-dialog.tsx
+++ b/src/components/app/training-dialog.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { Loader2 } from "lucide-react";
+
+interface TrainingDialogProps {
+  open: boolean;
+}
+
+export function TrainingDialog({ open }: TrainingDialogProps) {
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (!open) {
+      setProgress(0);
+      return;
+    }
+
+    const id = setInterval(() => {
+      setProgress((prev) => (prev >= 90 ? 10 : prev + 10));
+    }, 500);
+    return () => clearInterval(id);
+  }, [open]);
+
+  return (
+    <Dialog open={open}>
+      <DialogContent className="flex flex-col items-center gap-4">
+        <DialogHeader className="text-center">
+          <DialogTitle>Training Model</DialogTitle>
+          <DialogDescription>
+            Hang tight! We&apos;re training your AI model.
+          </DialogDescription>
+        </DialogHeader>
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <Progress value={progress} className="w-full" />
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- show overlay with progress while model trains
- implement `TrainingDialog` component for nicer UI

## Testing
- `npm run lint` *(fails: interactive eslint setup prompt)*
- `npm run typecheck` *(fails: src/ai/flows/visualize-screw-defects.ts:61:51 - Property 'prompt' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_688436a71a4c8321ac383893ec25d546