### PR TITLE
Handle missing training images

### DIFF
--- a/src/python/train_cs_flow.py
+++ b/src/python/train_cs_flow.py
@@ -84,9 +84,17 @@ def main() -> None:
     train_good.mkdir(parents=True, exist_ok=True)
     test_good.mkdir(parents=True, exist_ok=True)
 
-    test_count = min(2, len(args.images))
-    train_imgs = args.images[:-test_count] if len(args.images) > test_count else []
-    test_imgs = args.images[-test_count:]
+    if len(args.images) == 0:
+        print("No training images were provided", file=sys.stderr)
+        sys.exit(1)
+
+    if len(args.images) < 2:
+        train_imgs = args.images
+        test_imgs = args.images
+    else:
+        test_count = min(2, len(args.images))
+        train_imgs = args.images[:-test_count]
+        test_imgs = args.images[-test_count:]
 
     for idx, img in enumerate(train_imgs):
         dest = train_good / f"img_{idx}.png"


### PR DESCRIPTION
## Summary
- gracefully exit training if no images are provided
- ensure we always create a training set when only one image is available

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c267780e08321b6a592dd72981dae