### PR TITLE
Handle missing training images

### DIFF
--- a/src/components/app/reference-tab.tsx
+++ b/src/components/app/reference-tab.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Webcam from "react-webcam";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type MouseEvent } from "react";
 import { generateDefectProfile } from "@/ai/flows/generate-defect-profile";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,11 +32,25 @@ type Status = "idle" | "collecting" | "training" | "complete";
 
 export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
   const webcamRef = useRef<Webcam>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
   const [showCamera, setShowCamera] = useState(false);
   const [status, setStatus] = useState<Status>("idle");
   const [progress, setProgress] = useState(0);
   const [trainedModelId, setTrainedModelId] = useState<string | null>(null);
+  const [captureDuration, setCaptureDuration] = useState(60);
+  const [selecting, setSelecting] = useState(false);
+  const [cropRect, setCropRect] = useState<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
   const { toast } = useToast();
+
+  // Show the webcam as soon as this tab is opened
+  useEffect(() => {
+    setShowCamera(true);
+  }, []);
 
   useEffect(() => {
     let timer: NodeJS.Timeout | undefined;
@@ -50,6 +64,49 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
     };
   }, [status]);
 
+  const beginSelect = (e: MouseEvent<HTMLDivElement>) => {
+    if (status !== "idle") return;
+    const rect = overlayRef.current!.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    setCropRect({ x, y, width: 0, height: 0 });
+    setSelecting(true);
+  };
+
+  const updateSelect = (e: MouseEvent<HTMLDivElement>) => {
+    if (!selecting || !cropRect) return;
+    const rect = overlayRef.current!.getBoundingClientRect();
+    const width = e.clientX - rect.left - cropRect.x;
+    const height = e.clientY - rect.top - cropRect.y;
+    setCropRect({ ...cropRect, width, height });
+  };
+
+  const endSelect = () => {
+    setSelecting(false);
+  };
+
+  async function cropImage(dataUri: string): Promise<string> {
+    if (!cropRect) return dataUri;
+    const img = new Image();
+    img.src = dataUri;
+    await new Promise<void>(res => { img.onload = () => res(); });
+    const canvas = document.createElement("canvas");
+    const videoW = img.width;
+    const videoH = img.height;
+    const overlay = overlayRef.current?.getBoundingClientRect();
+    const scaleX = overlay ? videoW / overlay.width : 1;
+    const scaleY = overlay ? videoH / overlay.height : 1;
+    const x = Math.min(cropRect.x, cropRect.x + cropRect.width) * scaleX;
+    const y = Math.min(cropRect.y, cropRect.y + cropRect.height) * scaleY;
+    const w = Math.abs(cropRect.width) * scaleX;
+    const h = Math.abs(cropRect.height) * scaleY;
+    canvas.width = w;
+    canvas.height = h;
+    const ctx = canvas.getContext("2d")!;
+    ctx.drawImage(img, x, y, w, h, 0, 0, w, h);
+    return canvas.toDataURL("image/png");
+  }
+
   const startProcess = async () => {
     setStatus("collecting");
     setProgress(0);
@@ -59,11 +116,11 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
     await sendCommand("B1");
     const images: string[] = [];
     let count = 0;
-    const interval = setInterval(() => {
+    const interval = setInterval(async () => {
       const img = webcamRef.current?.getScreenshot();
-      if (img) images.push(img);
+      if (img) images.push(await cropImage(img));
       count++;
-      setProgress(Math.min(50, (count / 60) * 50));
+      setProgress(Math.min(50, (count / captureDuration) * 50));
     }, 1000);
     setTimeout(async () => {
       clearInterval(interval);
@@ -91,7 +148,7 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
       } finally {
         setShowCamera(false);
       }
-    }, 60000);
+    }, captureDuration * 1000);
   };
 
   return (
@@ -101,12 +158,37 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
           <Bot /> Reference Mode: Train Defect Profile
         </CardTitle>
         <CardDescription>
-          The system will collect images from the webcam for one minute while the
-          motors rotate, then train a defect profile.
+          Select an area of interest on the camera preview and specify how long
+          to capture images. The system will collect frames from only that
+          region while the motors rotate, then train a defect profile.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        {showCamera && <Webcam audio={false} ref={webcamRef} className="w-full rounded-md" />}
+        {showCamera && (
+          <div className="relative">
+            <Webcam audio={false} ref={webcamRef} className="w-full rounded-md" />
+            <div
+              ref={overlayRef}
+              className="absolute inset-0 cursor-crosshair"
+              onMouseDown={beginSelect}
+              onMouseMove={updateSelect}
+              onMouseUp={endSelect}
+              onMouseLeave={endSelect}
+            >
+              {cropRect && (
+                <div
+                  className="absolute border border-red-500"
+                  style={{
+                    left: Math.min(cropRect.x, cropRect.x + cropRect.width),
+                    top: Math.min(cropRect.y, cropRect.y + cropRect.height),
+                    width: Math.abs(cropRect.width),
+                    height: Math.abs(cropRect.height),
+                  }}
+                />
+              )}
+            </div>
+          </div>
+        )}
         {trainedModelId && status === "complete" && (
           <div className="p-4 rounded-md bg-primary/10 border border-primary/20 flex items-center gap-3">
             <CheckCircle className="text-primary h-6 w-6" />
@@ -118,6 +200,18 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
         )}
       </CardContent>
       <CardFooter className="flex flex-col gap-4">
+        <div className="flex items-center gap-2 w-full">
+          <label className="text-sm whitespace-nowrap text-foreground" htmlFor="trainTime">Capture Time (s)</label>
+          <input
+            id="trainTime"
+            type="number"
+            min={1}
+            className="border rounded px-2 py-1 flex-grow text-foreground"
+            value={captureDuration}
+            onChange={e => setCaptureDuration(Number(e.target.value))}
+            disabled={status !== "idle"}
+          />
+        </div>
         <Button onClick={startProcess} disabled={status === "collecting" || status === "training"} className="w-full">
           {status === "collecting" ? (
             <>

--- a/src/python/train_cs_flow.py
+++ b/src/python/train_cs_flow.py
@@ -84,9 +84,17 @@ def main() -> None:
     train_good.mkdir(parents=True, exist_ok=True)
     test_good.mkdir(parents=True, exist_ok=True)
 
-    test_count = min(2, len(args.images))
-    train_imgs = args.images[:-test_count] if len(args.images) > test_count else []
-    test_imgs = args.images[-test_count:]
+    if len(args.images) == 0:
+        print("No training images were provided", file=sys.stderr)
+        sys.exit(1)
+
+    if len(args.images) < 2:
+        train_imgs = args.images
+        test_imgs = args.images
+    else:
+        test_count = min(2, len(args.images))
+        train_imgs = args.images[:-test_count]
+        test_imgs = args.images[-test_count:]
 
     for idx, img in enumerate(train_imgs):
         dest = train_good / f"img_{idx}.png"


### PR DESCRIPTION
## Summary
- gracefully exit training if no images are provided
- ensure we always create a training set when only one image is available
- allow ROI selection and training duration before starting
- show webcam by default when entering the reference page
- clarify that the time field controls capture duration and improve its visibility

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c267780e08321b6a592dd72981dae