### PR TITLE
Stop motors during training snapshots

### DIFF
--- a/src/components/app/reference-tab.tsx
+++ b/src/components/app/reference-tab.tsx
@@ -133,8 +133,12 @@ export function ReferenceTab({ onModelTrained }: ReferenceTabProps) {
     const images: string[] = [];
     let count = 0;
     const interval = setInterval(async () => {
+      await sendCommand("A0");
+      await sendCommand("B0");
       const img = webcamRef.current?.getScreenshot();
       if (img) images.push(await cropImage(img));
+      await sendCommand("A1");
+      await sendCommand("B1");
       count++;
       setProgress(Math.min(50, (count / captureDuration) * 50));
 


### PR DESCRIPTION
## Summary
- capture training frames with motors temporarily stopped

## Testing
- `npm run typecheck`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688c4ddccd2883219cc34ec19fee2e4c