### PR TITLE
feat: support esp8266 serial speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,8 @@ The app can control two motors through an Arduino using the commands defined in
 `src/lib/arduino.ts`. Set the `ARDUINO_PORT` environment variable to the serial
 port where your Arduino is connected (for example `COM6` on Windows). If this
 variable is not provided the app attempts to auto-detect the first port that
-looks like an Arduino and falls back to `/dev/ttyACM0`. The new **Control** tab
-in the UI lets you send direction and speed commands to both motors.
+looks like an Arduino and falls back to `/dev/ttyACM0`. The firmware for an
+ESP8266 board is included in `docs/esp8266-motor-control.ino` and communicates
+at 115200 baud, which is the speed used by the server utilities. The new
+**Control** tab in the UI lets you send direction and speed commands to both
+motors.

--- a/docs/esp8266-motor-control.ino
+++ b/docs/esp8266-motor-control.ino
@@ -1,0 +1,72 @@
+// Motor A
+const uint8_t IN1 = D1;  // GPIO5
+const uint8_t IN2 = D2;  // GPIO4
+const uint8_t ENA = D3;  // GPIO0
+
+// Motor B
+const uint8_t IN3 = D5;  // GPIO14
+const uint8_t IN4 = D6;  // GPIO12
+const uint8_t ENB = D7;  // GPIO13
+
+int speedA = 120;
+int speedB = 120;
+
+void setup() {
+  pinMode(IN1, OUTPUT);
+  pinMode(IN2, OUTPUT);
+  pinMode(ENA, OUTPUT);
+  pinMode(IN3, OUTPUT);
+  pinMode(IN4, OUTPUT);
+  pinMode(ENB, OUTPUT);
+  Serial.begin(115200);  // Typical baud rate for ESP8266
+}
+
+void loop() {
+  if (Serial.available()) {
+    String cmd = Serial.readStringUntil('\n');
+    cmd.trim();
+
+    if (cmd.startsWith("A")) {
+      if (cmd == "A1") {
+        digitalWrite(IN1, HIGH);
+        digitalWrite(IN2, LOW);
+        analogWrite(ENA, speedA);
+      } else if (cmd == "A2") {
+        digitalWrite(IN1, LOW);
+        digitalWrite(IN2, HIGH);
+        analogWrite(ENA, speedA);
+      } else if (cmd == "A0") {
+        digitalWrite(IN1, LOW);
+        digitalWrite(IN2, LOW);
+        analogWrite(ENA, 0);
+      }
+    }
+
+    if (cmd.startsWith("B")) {
+      if (cmd == "B1") {
+        digitalWrite(IN3, HIGH);
+        digitalWrite(IN4, LOW);
+        analogWrite(ENB, speedB);
+      } else if (cmd == "B2") {
+        digitalWrite(IN3, LOW);
+        digitalWrite(IN4, HIGH);
+        analogWrite(ENB, speedB);
+      } else if (cmd == "B0") {
+        digitalWrite(IN3, LOW);
+        digitalWrite(IN4, LOW);
+        analogWrite(ENB, 0);
+      }
+    }
+
+    if (cmd.startsWith("SA")) {
+      speedA = constrain(cmd.substring(2).toInt(), 0, 1023);  // ESP8266 PWM range
+      analogWrite(ENA, speedA);
+    }
+
+    if (cmd.startsWith("SB")) {
+      speedB = constrain(cmd.substring(2).toInt(), 0, 1023);
+      analogWrite(ENB, speedB);
+    }
+  }
+}
+

--- a/motor-controller.js
+++ b/motor-controller.js
@@ -1,8 +1,10 @@
 const { SerialPort } = require('serialport');
 
 const port = new SerialPort({
-  path: 'COM6',
-  baudRate: 9600,
+  // Use ARDUINO_PORT if set, otherwise default to COM6
+  path: process.env.ARDUINO_PORT || 'COM6',
+  // Match the ESP8266 sketch's faster serial speed
+  baudRate: 115200,
 });
 
 port.on('open', () => {

--- a/src/lib/arduino.ts
+++ b/src/lib/arduino.ts
@@ -3,17 +3,19 @@
 import { SerialPort } from 'serialport'
 
 let port: SerialPort | null = null
-const baudRate = 9600
+// ESP8266 sketch uses a 115200 baud serial connection
+const baudRate = 115200
 
 /**
- * Gibt immer 'COM6' zurück – der Arduino-Port.
+ * Resolves the serial port to use for the Arduino/ESP8266.
+ * Uses the ARDUINO_PORT env variable or falls back to `COM6`.
  */
 async function resolvePortPath(): Promise<string> {
-  return 'COM6'
+  return process.env.ARDUINO_PORT || 'COM6'
 }
 
 /**
- * Öffnet den seriellen Port mit 9600 Baud.
+ * Öffnet den seriellen Port mit 115200 Baud.
  */
 async function createPort() {
   const path = await resolvePortPath()


### PR DESCRIPTION
## Summary
- document and ship ESP8266 motor controller firmware
- default serial helpers to 115200 baud with configurable port

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68924a29f9ec83219ea0af07deca1c7a