### PR TITLE
feat: add SAM-based background removal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 # firebase
 firebase-debug.log
 firestore-debug.log
+
+# SAM checkpoints
+src/python/sam/*.pth

--- a/README.md
+++ b/README.md
@@ -9,10 +9,14 @@ returned by the training flow. Pass this path to the analysis flow. Analysis
 returns a heatmap overlay image highlighting detected anomalies.
 Ensure your Python environment has the dependencies listed in CS-Flow's
 `requirements.txt` installed. In particular, `torch` and `torchvision` are
-required. OpenCV (`opencv-python-headless`) and `numpy` are also needed for
-automatic screw segmentation during training and inspection. Set the `PYTHON` environment
-variable if you want to use a custom Python interpreter. The scripts will
-automatically use CUDA if available, falling back to the CPU otherwise.
+required. OpenCV (`opencv-python-headless`), `numpy`, and
+[`segment-anything`](https://github.com/facebookresearch/segment-anything) are
+also needed for automatic screw segmentation during training and inspection.
+Download a SAM checkpoint such as `sam_vit_b.pth` and place it in
+`src/python/sam` or provide the path via the `--sam-checkpoint` option. Set the
+`PYTHON` environment variable if you want to use a custom Python interpreter.
+The scripts will automatically use CUDA if available, falling back to the CPU
+otherwise.
 
 The training wrapper patches CS-Flow's `train.py` so AUROC remains a neutral
 0.5 when the dataset only contains one class and noisy warnings are suppressed.

--- a/src/python/analyze_glass.py
+++ b/src/python/analyze_glass.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Analyze screw images using SAM-based background removal."""
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+import cv2
+import numpy as np
+from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+
+
+def remove_background(img: np.ndarray, checkpoint: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Remove background from an image using SAM.
+
+    Args:
+        img: Input image as a numpy array in BGR or RGB format.
+        checkpoint: Path to SAM checkpoint file.
+
+    Returns:
+        The masked image and boolean mask.
+    """
+    sam = sam_model_registry["vit_b"](checkpoint=checkpoint)
+    mask_generator = SamAutomaticMaskGenerator(sam)
+
+    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    masks = mask_generator.generate(rgb)
+    if not masks:
+        mask = np.zeros(rgb.shape[:2], dtype=bool)
+    else:
+        best = max(masks, key=lambda m: m.get("area", 0))
+        mask = best["segmentation"].astype(bool)
+
+    result = img.copy()
+    result[~mask] = 0
+    return result, mask
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze screw image (placeholder)")
+    default_ckpt = Path(__file__).resolve().parent / "sam" / "sam_vit_b.pth"
+    parser.add_argument(
+        "--sam-checkpoint",
+        default=str(default_ckpt),
+        help="Path to SAM checkpoint",
+    )
+    parser.add_argument("image", help="Image to analyze")
+    args = parser.parse_args()
+
+    image = cv2.imread(args.image)
+    if image is None:
+        raise FileNotFoundError(f"Image not found: {args.image}")
+
+    masked, mask = remove_background(image, args.sam_checkpoint)
+    cv2.imwrite("masked.png", masked)
+    cv2.imwrite("mask.png", mask.astype("uint8") * 255)
+    print("Background removed using SAM")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/python/train_glass.py
+++ b/src/python/train_glass.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Training utilities for glass inspection with SAM-based background removal."""
+
+import argparse
+from pathlib import Path
+from typing import Tuple
+
+import cv2
+import numpy as np
+from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+
+
+def remove_background(img: np.ndarray, checkpoint: str) -> Tuple[np.ndarray, np.ndarray]:
+    """Remove background from an RGB/BGR image using the Segment Anything Model.
+
+    Args:
+        img: Input image as a numpy array in BGR or RGB format.
+        checkpoint: Path to the SAM checkpoint file.
+
+    Returns:
+        A tuple of (masked_image, mask) where mask is a boolean array.
+    """
+    sam = sam_model_registry["vit_b"](checkpoint=checkpoint)
+    mask_generator = SamAutomaticMaskGenerator(sam)
+
+    rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
+    masks = mask_generator.generate(rgb)
+    if not masks:
+        mask = np.zeros(rgb.shape[:2], dtype=bool)
+    else:
+        best = max(masks, key=lambda m: m.get("area", 0))
+        mask = best["segmentation"].astype(bool)
+
+    result = img.copy()
+    result[~mask] = 0
+    return result, mask
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Train glass model (placeholder)")
+    default_ckpt = Path(__file__).resolve().parent / "sam" / "sam_vit_b.pth"
+    parser.add_argument(
+        "--sam-checkpoint",
+        default=str(default_ckpt),
+        help="Path to SAM checkpoint",
+    )
+    parser.add_argument("image", help="Sample image for background removal")
+    args = parser.parse_args()
+
+    image = cv2.imread(args.image)
+    if image is None:
+        raise FileNotFoundError(f"Image not found: {args.image}")
+
+    masked, mask = remove_background(image, args.sam_checkpoint)
+    cv2.imwrite("masked.png", masked)
+    cv2.imwrite("mask.png", mask.astype("uint8") * 255)
+    print("Background removed using SAM")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add SAM-based `remove_background` with mask selection for train and analyze scripts
- document segment-anything dependency and checkpoint handling
- ignore SAM checkpoint files

## Testing
- `python -m py_compile src/python/train_glass.py src/python/analyze_glass.py`

------
https://chatgpt.com/codex/tasks/task_e_6896d64280c083219f3e9200f02ea238